### PR TITLE
Update Companion facts and legal disclosures

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <url>
         <loc>https://hanami.yorunoken.com/</loc>
-        <lastmod>2026-07-16</lastmod>
+        <lastmod>2026-07-18</lastmod>
     </url>
     <url>
         <loc>https://hanami.yorunoken.com/bot</loc>
@@ -10,11 +10,11 @@
     </url>
     <url>
         <loc>https://hanami.yorunoken.com/osuguessr</loc>
-        <lastmod>2026-07-16</lastmod>
+        <lastmod>2026-07-18</lastmod>
     </url>
     <url>
         <loc>https://hanami.yorunoken.com/companion</loc>
-        <lastmod>2026-07-16</lastmod>
+        <lastmod>2026-07-18</lastmod>
     </url>
     <url>
         <loc>https://hanami.yorunoken.com/map-analyzer</loc>
@@ -22,19 +22,19 @@
     </url>
     <url>
         <loc>https://hanami.yorunoken.com/legal</loc>
-        <lastmod>2026-07-16</lastmod>
+        <lastmod>2026-07-18</lastmod>
     </url>
     <url>
         <loc>https://hanami.yorunoken.com/legal/privacy</loc>
-        <lastmod>2026-07-16</lastmod>
+        <lastmod>2026-07-18</lastmod>
     </url>
     <url>
         <loc>https://hanami.yorunoken.com/legal/terms</loc>
-        <lastmod>2026-07-16</lastmod>
+        <lastmod>2026-07-18</lastmod>
     </url>
     <url>
         <loc>https://hanami.yorunoken.com/legal/cookies</loc>
-        <lastmod>2026-07-16</lastmod>
+        <lastmod>2026-07-18</lastmod>
     </url>
     <url>
         <loc>https://hanami.yorunoken.com/legal/data-deletion</loc>

--- a/src/client/pages/Companion.tsx
+++ b/src/client/pages/Companion.tsx
@@ -1,4 +1,4 @@
-import { Github, HardDrive, MonitorDot, Radio, UploadCloud } from "lucide-react";
+import { Github, HardDrive, KeyRound, MonitorDot, Radio, UploadCloud } from "lucide-react";
 
 import { ActionLink, Eyebrow, SectionIntro, StatusLine } from "@/components/marketing";
 import {
@@ -19,9 +19,9 @@ import {
 import { getProduct } from "@/data/site-config";
 
 const currentCapabilities = [
-    ["Tauri shell", "A Rust-backed desktop prototype with a React interface."],
-    ["tosu process control", "The app can start and stop a local tosu process."],
-    ["Local state events", "It listens for local play-state changes over tosu’s WebSocket."],
+    ["tosu lifecycle", "Connect to an existing tosu instance or launch and stop one owned by Companion."],
+    ["Play detection", "Track selected beatmaps and detect passed, failed, retried, and quit attempts."],
+    ["Native Hanami sign-in", "Authenticate through the system browser with Authorization Code and PKCE."],
 ] as const;
 
 export default function Companion() {
@@ -32,15 +32,16 @@ export default function Companion() {
             <ProductHero className="bg-[linear-gradient(130deg,rgba(128,215,232,0.08),transparent_42%),#0b0c0f]">
                 <div className={productHeroCopyClass}>
                     <Eyebrow>Desktop prototype</Eyebrow>
-                    <StatusLine status={product.status} detail="No public application source or packaged release" tone={product.tone} />
+                    <StatusLine status={product.status} detail="Public source · no packaged release" tone={product.tone} />
                     <h1 className={productTitleClass}>{product.name}</h1>
                     <h2 className={productSubtitleClass}>A local bridge for ideas that do not belong in a browser.</h2>
                     <p className={productBodyClass}>
-                        A local development worktree explores a Tauri shell that can manage tosu and observe local osu! state. The public
-                        repository currently contains only its license, and Hanami account connection and score upload remain mocked.
+                        The public Tauri prototype uses Rust for process lifecycle, local play detection, and native authentication while React
+                        renders normalized state. It can connect to tosu, track local osu! activity, and sign in to Hanami Web; play upload
+                        remains unavailable.
                     </p>
                     <ActionLink className="mt-8" href={product.links.primary} external>
-                        <Github aria-hidden="true" /> View the project repository
+                        <Github aria-hidden="true" /> View the source
                     </ActionLink>
                 </div>
 
@@ -53,7 +54,7 @@ export default function Companion() {
                         height="512"
                     />
                     <figcaption className="mx-auto mt-4 max-w-[45ch] text-[0.72rem] leading-[1.55] text-quiet max-[600px]:text-left">
-                        Current project icon. The desktop application is not yet distributed.
+                        Current project icon. No packaged release is published yet.
                     </figcaption>
                 </figure>
             </ProductHero>
@@ -61,8 +62,8 @@ export default function Companion() {
             <ProductSection>
                 <SectionIntro
                     eyebrow="Implemented now"
-                    title="A narrow local prototype."
-                    body="These capabilities were verified in the local development worktree. They are not yet available as public source or a release."
+                    title="A functional local prototype."
+                    body="These capabilities are implemented in the public repository. The project remains in development and does not yet offer a packaged release."
                 />
                 <div className="grid grid-cols-1 border-t border-border-strong min-[821px]:grid-cols-3">
                     {currentCapabilities.map(([title, description]) => (
@@ -80,31 +81,36 @@ export default function Companion() {
             <ProductSplit>
                 <div>
                     <Eyebrow>Data boundary</Eyebrow>
-                    <h2 className={sectionHeadingClass}>Local first, with the network path still unfinished.</h2>
+                    <h2 className={sectionHeadingClass}>Local tracking first. Upload is deliberately unavailable.</h2>
                     <p className={sectionBodyClass}>
-                        The prototype connects to a local tosu WebSocket. Its Hanami API client only prints mock score and map-upload
-                        messages; the network requests are commented out.
+                        Recent attempts stay in memory for the current desktop session. Hanami sign-in uses the system browser and PKCE; the
+                        access token stays in Rust memory and the refresh token is stored in the operating system credential store. Hanami Web
+                        does not yet expose a production play-ingestion endpoint.
                     </p>
                 </div>
                 <ProductSteps className="[&_svg]:text-cyan">
                     <ProductStep icon={<HardDrive aria-hidden="true" />}>
                         <strong>Local osu! session</strong>
-                        <p>tosu reads local game state.</p>
+                        <p>tosu reads local game state and exposes it over loopback.</p>
                     </ProductStep>
                     <ProductStep icon={<Radio aria-hidden="true" />}>
                         <strong>Companion listener</strong>
-                        <p>The app observes state transitions.</p>
+                        <p>The app normalizes state and detects meaningful play attempts.</p>
+                    </ProductStep>
+                    <ProductStep icon={<KeyRound aria-hidden="true" />}>
+                        <strong>Hanami authentication</strong>
+                        <p>Authorization Code with PKCE is implemented through the system browser.</p>
                     </ProductStep>
                     <ProductStep icon={<UploadCloud aria-hidden="true" />} muted>
-                        <strong>Hanami sync — planned</strong>
-                        <p>No production upload endpoint is active.</p>
+                        <strong>Play upload — planned</strong>
+                        <p>No production ingestion endpoint is active, and attempts are never reported as uploaded.</p>
                     </ProductStep>
                 </ProductSteps>
             </ProductSplit>
 
             <ProductFootnote className="[&>svg]:text-cyan">
                 <MonitorDot aria-hidden="true" />
-                <p>No release download is offered, and the application source has not yet been published to the public repository.</p>
+                <p>The source is public, but no packaged release is currently offered. Play upload remains unavailable.</p>
             </ProductFootnote>
         </ProductPage>
     );

--- a/src/client/pages/Home.tsx
+++ b/src/client/pages/Home.tsx
@@ -138,8 +138,8 @@ export default function Home() {
                                 Useful on its own. Connected only when it helps.
                             </h2>
                             <p className="mt-5 max-w-[62ch] text-[clamp(1rem,1.4vw,1.1rem)] leading-7 text-muted">
-                                Published Hanami code, issues, and project history are public. Live products and released tools are labeled
-                                separately from development work whose application source is not yet published.
+                                Published Hanami code, issues, and project history are public. Live products, released packages, and
+                                in-development prototypes are labeled separately so their current state is clear.
                             </p>
                             <TextLink className="mt-[1.8rem]" href={siteConfig.links.organization} external>
                                 Browse the repositories

--- a/src/client/pages/OsuGuessr.tsx
+++ b/src/client/pages/OsuGuessr.tsx
@@ -149,10 +149,7 @@ export default function OsuGuessr() {
             </ProductSplit>
 
             <ProductFootnote>
-                <p>
-                    osu!guessr is a separate hosted service with its own authentication, browser storage, analytics, and advertising
-                    behavior.
-                </p>
+                <p>osu!guessr is a separate hosted service with its own authentication, browser storage, and analytics behavior.</p>
                 <TextLink href="/legal/privacy">Read the ecosystem privacy policy</TextLink>
             </ProductFootnote>
         </ProductPage>

--- a/src/components/legal/cookie-policy.tsx
+++ b/src/components/legal/cookie-policy.tsx
@@ -218,23 +218,18 @@ export default function CookiePolicy() {
                     Both public sites are proxied through Cloudflare. Depending on the security and traffic features triggered for a
                     request, Cloudflare may set strictly necessary cookies such as <code>__cf_bm</code> for bot protection or{" "}
                     <code>cf_clearance</code> after a challenge. Cloudflare documents <code>__cf_bm</code> as expiring after 30 minutes of
-                    inactivity; challenge-cookie lifetime depends on the configured protection. These cookies are conditional and were not
-                    present in the ordinary live responses checked during this audit. See{" "}
+                    inactivity; challenge-cookie lifetime depends on the configured protection. See{" "}
                     <a href={siteConfig.links.cloudflareCookies} target="_blank" rel="noreferrer">
                         Cloudflare’s cookie documentation
                     </a>
                     .
                 </p>
                 <p>
-                    osu!guessr loads self-hosted Umami from <code>umami.yorunoken.com</code> for aggregate analytics and Google AdSense for
-                    advertising in production. Umami is intended to operate without analytics cookies or personal-data collection. Google
-                    and its advertising partners may use cookies or local storage and receive device, network, page, and ad-interaction
-                    data. The exact names and lifetimes can vary by region, consent choice, browser, and Google’s current configuration.
+                    osu!guessr loads self-hosted Umami from <code>umami.yorunoken.com</code> for aggregate analytics. Umami does not set
+                    analytics cookies. Request and device information such as IP address and user agent may be processed to derive aggregate
+                    session and location metrics, while raw IP addresses are not intended to be stored.
                 </p>
-                <p>
-                    No tracking pixel or third-party iframe was found in the audited source. Google AdSense can make additional network
-                    requests and inject ad content at runtime.
-                </p>
+                <p>No advertising script, tracking pixel, or third-party iframe is loaded by the audited application source.</p>
             </LegalSection>
 
             <LegalSection id="choices" title="6. Choices and consent">
@@ -244,17 +239,9 @@ export default function CookiePolicy() {
                     and using browser controls; authentication will not work without the session cookie.
                 </p>
                 <p>
-                    osu!guessr’s analytics and advertising scripts are non-essential and currently load after the production page starts.
-                    The audited repository does not delay those scripts behind its own consent control. Google may present a consent message
-                    through publisher-account configuration, which is not visible in the repository. Google requires publishers serving ads
-                    in the EEA, UK, or Switzerland to use a certified consent-management platform for personalized ads. You can also manage
-                    ad personalization through{" "}
-                    <a href={siteConfig.links.googleAdsSettings} target="_blank" rel="noreferrer">
-                        Google Ads Settings
-                    </a>{" "}
-                    and block or clear storage through browser controls. Blocking these scripts can prevent ads and aggregate analytics but
-                    should not prevent the core game from working. This inventory describes the implementation; it is not evidence that a
-                    deployment-level consent configuration is complete.
+                    osu!guessr’s self-hosted Umami script is non-essential and loads after the production page starts. Blocking it prevents
+                    aggregate analytics but should not prevent the core game from working. Browser controls or content blockers can stop the
+                    request; Umami does not use an analytics cookie to recognize the browser.
                 </p>
             </LegalSection>
 

--- a/src/components/legal/privacy-policy.tsx
+++ b/src/components/legal/privacy-policy.tsx
@@ -42,14 +42,13 @@ export default function PrivacyPolicy() {
             <LegalSection id="scope" title="2. Services covered">
                 <p>
                     This policy is intended to cover the Hanami ecosystem operated by the controller: this website and account area, Hanami
-                    Bot on Discord, the separately hosted osu!guessr service, and any networked Hanami Companion feature if it is enabled
-                    later.
+                    Bot on Discord, the separately hosted osu!guessr service, and networked features in the public Hanami Companion prototype.
                 </p>
                 <p>
                     Map Analyzer 0.2.9 is a separately distributed Rust library. The published crate parses local files and has no network
                     client dependency or command-line binary. Broader CLI and dataset work exists only in an unpublished development
-                    worktree. Companion is also unreleased: its public repository currently contains only a license, while the local
-                    prototype’s Hanami score-upload request is mocked and commented out.
+                    worktree. Companion is public source but remains unreleased: local tracking and Hanami authentication are implemented,
+                    while play upload is unavailable because Hanami Web does not expose a production ingestion endpoint.
                 </p>
             </LegalSection>
 
@@ -161,9 +160,25 @@ export default function PrivacyPolicy() {
                         storage, and theme storage supplied by next-themes.
                     </li>
                     <li>
-                        Production pages load self-hosted Umami for aggregate analytics and Google AdSense for advertising. Umami is
-                        intended to operate without analytics cookies. Google and its advertising partners may use cookies or local storage
-                        and process device, network, page, and ad-interaction data under their own settings and policies.
+                        Production pages load self-hosted Umami for aggregate analytics. Umami is configured to operate without analytics
+                        cookies. Request and device information may be processed to derive aggregate session and location metrics; raw IP
+                        addresses are not intended to be stored by the analytics service.
+                    </li>
+                </ul>
+
+                <h3>Hanami Companion prototype</h3>
+                <ul>
+                    <li>
+                        Selected beatmap, live gameplay, and attempt-state information received from a local tosu instance. Recent attempts
+                        are retained in memory for the current application session and are not written to a Companion database.
+                    </li>
+                    <li>
+                        Hanami sign-in opens the system browser and uses Authorization Code with PKCE through a temporary loopback listener.
+                        The access token remains in Rust memory and the refresh token is stored in the operating system credential store.
+                    </li>
+                    <li>
+                        Authorization codes, PKCE verifiers, and tokens are not exposed to the React interface or written to Companion
+                        application files. Play upload is currently unavailable and no attempt is reported as successfully submitted.
                     </li>
                 </ul>
 
@@ -200,8 +215,8 @@ export default function PrivacyPolicy() {
                             </td>
                         </tr>
                         <tr>
-                            <td>Optional analytics or advertising on osu!guessr.</td>
-                            <td>Consent where required; otherwise legitimate interests where applicable law permits.</td>
+                            <td>Measure aggregate osu!guessr usage and service reliability.</td>
+                            <td>Legitimate interests in understanding and maintaining the service, subject to applicable law.</td>
                         </tr>
                         <tr>
                             <td>Meet binding legal obligations and respond to valid legal process.</td>
@@ -214,15 +229,15 @@ export default function PrivacyPolicy() {
             <LegalSection id="sharing" title="5. Third parties and international processing">
                 <p>
                     Data is transmitted as needed to Discord for sign-in, bot operation, webhooks, and error reporting; to osu! for sign-in
-                    and API lookups; to Cloudflare as the public sites’ proxy and network provider; and to Google AdSense on osu!guessr.
-                    Hanami-controlled application, database, Redis, and self-hosted Umami infrastructure is hosted in Germany.
+                    and API lookups; and to Cloudflare as the public sites’ proxy and network provider. Hanami-controlled application,
+                    database, Redis, and self-hosted Umami infrastructure is hosted in Germany.
                 </p>
                 <p>
                     The operator manages the services from Türkiye while Hanami-controlled production data is processed on infrastructure in
-                    Germany. Processing may also cross other national borders because Discord, osu!, Google, and some service providers
-                    operate internationally. Third-party handling is governed by each provider’s own terms, privacy notice, and applicable
-                    transfer mechanisms. The public repositories do not establish the physical location of every provider request or the
-                    operator’s production-access roster.
+                    Germany. Processing may also cross other national borders because Discord, osu!, and some service providers operate
+                    internationally. Third-party handling is governed by each provider’s own terms, privacy notice, and applicable transfer
+                    mechanisms. The public repositories do not establish the physical location of every provider request or the operator’s
+                    production-access roster.
                 </p>
                 <p>
                     See the providers’ own notices, including{" "}
@@ -232,10 +247,6 @@ export default function PrivacyPolicy() {
                     ,{" "}
                     <a href={siteConfig.links.osuPrivacy} target="_blank" rel="noreferrer">
                         osu!’s privacy policy
-                    </a>
-                    , and{" "}
-                    <a href={siteConfig.links.googlePrivacy} target="_blank" rel="noreferrer">
-                        Google’s privacy policy
                     </a>
                     , and{" "}
                     <a href={siteConfig.links.cloudflarePrivacy} target="_blank" rel="noreferrer">
@@ -266,11 +277,15 @@ export default function PrivacyPolicy() {
                         lasts for the browser-tab session.
                     </li>
                     <li>
+                        Companion recent-attempt data remains in memory until the application exits. Its stored refresh token remains in the
+                        operating system credential store until sign-out, token rejection, or removal through the operating system.
+                    </li>
+                    <li>
                         Account, provider-link, preference, guild, completed-game, report, and API-key metadata remain while the related
                         account or feature is active, until the user deletes or revokes them where a control exists, or until Hanami no
                         longer needs them for the service, security, or a legal obligation. Cached scores and maps are refreshed or
                         overwritten as the services operate. The source does not define a general automatic deletion schedule for these
-                        database rows. Analytics and advertising providers apply their own retention settings.
+                        database rows. The analytics service applies its configured retention settings.
                     </li>
                     <li>Short-lived account-deletion reauthentication challenges expire after approximately 15 minutes.</li>
                     <li>

--- a/src/components/legal/tos.tsx
+++ b/src/components/legal/tos.tsx
@@ -34,9 +34,9 @@ export default function TermsOfService() {
 
             <LegalSection id="scope" title="2. Service scope">
                 <p>
-                    The hosted services include this website and account area, Hanami Bot on Discord, and osu!guessr. Hanami Companion is an
-                    unreleased local prototype and Map Analyzer is a separately distributed Rust library. Repository code, locally run
-                    copies, and third-party platforms are subject to their own licenses and terms.
+                    The hosted services include this website and account area, Hanami Bot on Discord, and osu!guessr. Hanami Companion is a
+                    public-source but unreleased local prototype, and Map Analyzer is a separately distributed Rust library. Repository code,
+                    locally run copies, and third-party platforms are subject to their own licenses and terms.
                 </p>
                 <p>
                     Hanami provides osu!-related lookups, Discord commands, a beatmap guessing game, account-linking and preference tools,
@@ -102,8 +102,8 @@ export default function TermsOfService() {
                 </p>
                 <p>
                     Features marked prototype, beta, experimental, planned, or unfinished may be incomplete, lose data, change format, or
-                    never be released. Companion’s Hanami sync and upload path is not currently operational. The operator may modify or
-                    retire products and integrations, with reasonable notice where practical.
+                    never be released. Companion implements local tracking and Hanami authentication, but play upload is not currently
+                    operational. The operator may modify or retire products and integrations, with reasonable notice where practical.
                 </p>
                 <p>
                     Signed-in account deletion immediately removes the website identity and Discord-keyed Hanami Bot account data described

--- a/src/data/legal.ts
+++ b/src/data/legal.ts
@@ -4,6 +4,6 @@ export const legalContacts = {
 } as const;
 
 export const legalMetadata = {
-    lastUpdated: "July 16, 2026",
-    effectiveDate: "July 16, 2026",
+    lastUpdated: "July 18, 2026",
+    effectiveDate: "July 18, 2026",
 } as const;

--- a/src/data/site-config.ts
+++ b/src/data/site-config.ts
@@ -10,8 +10,6 @@ export const siteConfig = {
         support: "https://yorunoken.com#support",
         discordPrivacy: "https://discord.com/privacy",
         osuPrivacy: "https://osu.ppy.sh/legal/en/Privacy",
-        googlePrivacy: "https://policies.google.com/privacy",
-        googleAdsSettings: "https://adssettings.google.com/",
         cloudflarePrivacy: "https://www.cloudflare.com/privacypolicy/",
         cloudflareCookies: "https://developers.cloudflare.com/fundamentals/reference/policies-compliances/cloudflare-cookies/",
         kvkk: "https://www.kvkk.gov.tr/",
@@ -81,7 +79,7 @@ export const products: readonly ProductSummary[] = [
         status: "Development",
         category: "Desktop app",
         headline: "A local bridge, still taking shape.",
-        description: "An unpublished Tauri prototype for reading local osu! state through tosu.",
+        description: "A public Tauri prototype for local osu! tracking, tosu lifecycle control, and Hanami authentication.",
         action: "See the prototype",
         tone: "cyan",
         links: {
@@ -147,7 +145,7 @@ export const routeMetadata = {
     },
     "/companion": {
         title: "Hanami Companion — desktop prototype",
-        description: "Follow development of an unpublished Hanami Companion prototype for local osu! state tracking through tosu.",
+        description: "Follow the public Hanami Companion prototype for local osu! tracking, tosu control, and native Hanami authentication.",
         indexable: true,
         socialImage: "/products/companion-icon.png",
     },


### PR DESCRIPTION
## What changed

- Rewrote the Companion product page to match the current public Tauri prototype.
- Documented implemented tosu lifecycle control, local play detection, system-browser PKCE authentication, in-memory access tokens, and operating-system credential storage.
- Kept the remaining boundary explicit: there is no packaged release and play upload is unavailable until Hanami Web exposes an ingestion endpoint.
- Updated homepage and SEO metadata that incorrectly described Companion as unpublished.
- Updated the Privacy Policy and Terms to reflect Companion's current local and network behavior.
- Removed obsolete AdSense disclosures and links from the central Hanami legal pages, while retaining the self-hosted Umami disclosure.
- Updated legal effective dates and relevant sitemap dates.

## Why

The website described the Companion repository as license-only and its Hanami authentication as mocked, but the public repository now contains a functional prototype with native authentication and local tracking. The central policy also described an AdSense integration that is not in use.

## Paired change

`hanami-osu/osu-guessr#44` removes the unused AdSense loader and redirects osu!guessr's old legal routes to these canonical Hanami notices. Merge the paired PR before or alongside this one so the deployment matches the updated disclosure.

## Privacy note

This change does not add or expose the operator's legal name. Existing public identification remains unchanged.

## Validation

- Compared the copy against the current `hanami-osu/companion` README and implementation boundaries.
- Reviewed the complete branch diff against `frontend-architecture-prefetch`.
- Local format, typecheck, test, and build commands still need to run from a checkout with dependencies installed.